### PR TITLE
Modified for starter zendesk accounts

### DIFF
--- a/lib/zenpush.rb
+++ b/lib/zenpush.rb
@@ -11,7 +11,7 @@ module ZenPush
     @z ||= ZenPush::Zendesk.new
   end
 
-  # 
+  #
   def file_to_category_forum_entry(file)
     absolute_path = File.realpath(file)
     parts = absolute_path.split('/')

--- a/lib/zenpush/zendesk.rb
+++ b/lib/zenpush/zendesk.rb
@@ -78,7 +78,7 @@ module ZenPush
     # Find forum by name, knowing the category name
     def find_forum(category_name, forum_name, options = {})
       category = self.find_category(category_name, options)
-      if category
+      if category || mode == 'starter'
         self.forums.detect {|f| f['name'] == forum_name}
       end
     end

--- a/lib/zenpush/zendesk.rb
+++ b/lib/zenpush/zendesk.rb
@@ -10,12 +10,15 @@ module ZenPush
     headers 'Content-Type' => 'application/json'
     # debug_output
 
-    def initialize(b = nil, u = nil, p = nil)
+    attr_reader :mode
+
+    def initialize(b = nil, u = nil, p = nil, m = nil)
       if b.nil? || u.nil? || p.nil?
         creds = YAML.load_file(File.join(ENV['HOME'], '.zenpush.yml'))
         b ||= creds['uri']
         u ||= creds['user']
         p ||= creds['password']
+        @mode = creds['mode']
       end
 
       self.class.base_uri b + '/api/v1'
@@ -68,6 +71,7 @@ module ZenPush
 
     # Find category by name
     def find_category(category_name, options = {})
+      return nil if mode == 'starter'
       self.categories.detect {|c| c['name'] == category_name}
     end
 
@@ -77,6 +81,7 @@ module ZenPush
       if category
         self.forums.detect {|f| f['name'] == forum_name}
       end
+      self.forums.detect {|f| f['name'] == forum_name}
     end
 
     # Find entry by name, knowing the forum name and category name

--- a/lib/zenpush/zendesk.rb
+++ b/lib/zenpush/zendesk.rb
@@ -12,7 +12,7 @@ module ZenPush
 
     attr_reader :mode
 
-    def initialize(b = nil, u = nil, p = nil, m = nil)
+    def initialize(b = nil, u = nil, p = nil)
       if b.nil? || u.nil? || p.nil?
         creds = YAML.load_file(File.join(ENV['HOME'], '.zenpush.yml'))
         b ||= creds['uri']
@@ -81,7 +81,6 @@ module ZenPush
       if category
         self.forums.detect {|f| f['name'] == forum_name}
       end
-      self.forums.detect {|f| f['name'] == forum_name}
     end
 
     # Find entry by name, knowing the forum name and category name


### PR DESCRIPTION
People with starter versions of zendesk can now use zenpush. #2

Made the following change to my `.zenpush.yml` file:

```

---
uri: https://myproduct.zendesk.com
user: email@address.com/token
password: LoDsQlEtBXSd8clW87DgWi0VNFod3U9xQggzwJEH
mode: starter
```

Combined with the changes to `/zenpush/zendesk.rb` disregards any need for a category.

This will allow matches on the forum name only, disregarding the category.
