### PR TITLE
Added support for markdown flavors. 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,34 @@
 PATH
   remote: .
   specs:
-    zenpush (0.1.1)
+    zenpush (0.2.0)
       awesome_print (~> 1.0.0)
       boson (~> 1.0)
       httparty (~> 0.8.0)
       json_pure (~> 1.5.1)
+      pygments.rb (~> 0.4.2)
       redcarpet (~> 2.1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     awesome_print (1.0.2)
-    boson (1.1.0)
-    httparty (0.8.1)
-      multi_json
+    boson (1.2.4)
+    httparty (0.8.3)
+      multi_json (~> 1.0)
       multi_xml
-    json_pure (1.5.4)
+    json_pure (1.5.5)
       spruz (~> 0.2.8)
-    multi_json (1.4.0)
-    multi_xml (0.4.1)
+    multi_json (1.6.1)
+    multi_xml (0.5.3)
+    posix-spawn (0.3.6)
+    pygments.rb (0.4.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
     rake (0.9.2.2)
-    redcarpet (2.1.0)
+    redcarpet (2.1.1)
     spruz (0.2.13)
+    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby

--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,16 @@ Following the previous example, you would type:
 
 The gem will automatically discover the category and forum name of a given entry file. It will also convert your Markdown syntax in HTML before sending it to Zendesk.
 
+### Markdown Flavors
+
+ZenPush supports two different flavors of markdown: 'standard' and 'github'. The latter flavor supports Github specific
+syntax such as fenced code blocks and language specific highlighting.
+
+Language highlighting alters the HTML inside code blocks to support styling. You will still need to specify the
+appropriate CSS in your Zendesk account. Highlighting uses Pygments and any of the Pygments styles can be applied.
+
+    $ zp push -f <path_to_markdown_file> -F github
+
 ### Check if an entry exists
 
     $ zp exists? -f <path_to_markdown_file>

--- a/lib/zenpush/flavors/github.rb
+++ b/lib/zenpush/flavors/github.rb
@@ -1,0 +1,41 @@
+# encoding: UTF-8
+require 'redcarpet'
+require 'pygments'
+
+module ZenPush
+  module Flavors
+
+    class SyntaxRenderer < Redcarpet::Render::HTML
+      def block_code(code, language)
+        if language && !language.empty?
+          Pygments.highlight(code, :options => {:lexer => language.to_sym, :encoding => 'utf-8'})
+        else
+          "<pre>#{code}</pre>"
+        end
+      end
+    end
+
+    module Github
+      def self.to_html(text)
+        renderer = SyntaxRenderer.new(optionize [
+          :with_toc_data,
+          :hard_wrap,
+          :xhtml
+        ])
+        markdown = Redcarpet::Markdown.new(renderer, optionize([
+          :fenced_code_blocks,
+          :no_intra_emphasis,
+          :tables,
+          :autolink,
+          :strikethrough,
+          :space_after_headers
+        ]))
+        markdown.render(text)
+      end
+
+      def self.optionize(options)
+        options.each_with_object({}) { |option, memo| memo[option] = true }
+      end
+    end
+  end
+end

--- a/lib/zenpush/flavors/standard.rb
+++ b/lib/zenpush/flavors/standard.rb
@@ -1,0 +1,13 @@
+# encoding: UTF-8
+require 'redcarpet/compat'
+
+module ZenPush
+  module Flavors
+    module Standard
+      def self.to_html(content)
+        ::Markdown.new(content).to_html.gsub(/<\/?code>/, '')
+      end
+    end
+  end
+end
+

--- a/lib/zenpush/markdown.rb
+++ b/lib/zenpush/markdown.rb
@@ -1,13 +1,29 @@
 # encoding: UTF-8
-require 'redcarpet/compat'
 
 module ZenPush
-  class Markdown
+  module Flavors
+    FILES = Dir[File.join(File.dirname(__FILE__), 'flavors', '**', '*.rb')].freeze
+    NAMES = FILES.collect { |f| File.basename(f, '.rb') }.freeze
+    FILES.each do |file|
+      require file
+    end
+  end
 
-    # Convert a markdown file to HTML, removing all <code> tags,
-    # which make Zendesk remove carriage returns.
-    def self.to_zendesk_html(file)
-      ::Markdown.new(File.read(file)).to_html.gsub(/<\/?code>/, '')
+  class Markdown
+    def self.to_zendesk_html(file, flavor=nil)
+      select_flavor(flavor).to_html(File.read(file))
+    end
+
+    def self.select_flavor(flavor)
+      flavor ||= :standard
+      flavor_class_name = flavor.to_s.capitalize.to_sym
+      if ZenPush::Flavors.const_defined?(flavor_class_name)
+        ZenPush::Flavors.const_get(flavor_class_name)
+      else
+        raise "The '#{flavor}' flavor is not supported. Use: #{ZenPush::Flavors::NAMES.join(', ')}."
+      end
     end
   end
 end
+
+

--- a/lib/zenpush/runner.rb
+++ b/lib/zenpush/runner.rb
@@ -31,12 +31,13 @@ module ZenPush
 
     desc 'Create or update an entry from the given file'
     option :file, :type => :string
+    option :flavor, :type => :string
     def push(options = {})
       category_name, forum_name, entry_title = ZenPush.file_to_category_forum_entry(options[:file])
 
       entry_body =
         if options[:file].end_with?('.md') || options[:file].end_with?('.markdown')
-          ZenPush::Markdown.to_zendesk_html(options[:file])
+          ZenPush::Markdown.to_zendesk_html(options[:file], options[:flavor])
         else
           File.read(options[:file])
         end

--- a/zenpush.gemspec
+++ b/zenpush.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
-  
+
   s.add_dependency "boson", "~> 1.0" # Command line
   s.add_dependency "httparty", "~> 0.8.0" # Zendesk API calls
   s.add_dependency "redcarpet", "~> 2.1.0" # Markdown to HTML
+  s.add_dependency "pygments.rb", "~> 0.4.2" # Code highlighting for Github flavored markdown
   s.add_dependency "awesome_print", "~> 1.0.0" # Colorized output of Zendesk responses
   s.add_dependency "json_pure", "~> 1.5.1" # The C-gem "json" will still be used instead if it's installed
 


### PR DESCRIPTION
This pull request does not change zenpush defaults. 

A new -F parameter can now be used to specify what flavor of markdown will be used. The default is `standard`, which was the only flavor available prior to this pull. 

The new `github` flavor allows some of the non-standard markdown features available in github such as fenced code blocks and language-specific code highlighting.
