### PR TITLE
Linked images are uploaded on push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 *.gem
 .bundle
+.ruby_version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,13 @@
 PATH
   remote: .
   specs:
-    zenpush (0.2.0)
+    zenpush (0.3.0)
       awesome_print (~> 1.0.0)
       boson (~> 1.0)
-      httparty (~> 0.8.0)
+      httparty (~> 0.9.0)
       json_pure (~> 1.5.1)
+      nokogiri
+      persistent_httparty (~> 0.1.1)
       pygments.rb (~> 0.4.2)
       redcarpet (~> 2.1.0)
 
@@ -14,13 +16,20 @@ GEM
   specs:
     awesome_print (1.0.2)
     boson (1.2.4)
-    httparty (0.8.3)
+    gene_pool (1.3.0)
+    httparty (0.9.0)
       multi_json (~> 1.0)
       multi_xml
     json_pure (1.5.5)
       spruz (~> 0.2.8)
     multi_json (1.6.1)
     multi_xml (0.5.3)
+    nokogiri (1.5.6)
+    persistent_http (1.0.5)
+      gene_pool (>= 1.3)
+    persistent_httparty (0.1.1)
+      httparty (~> 0.9)
+      persistent_http
     posix-spawn (0.3.6)
     pygments.rb (0.4.2)
       posix-spawn (~> 0.3.6)

--- a/README.markdown
+++ b/README.markdown
@@ -72,6 +72,17 @@ The gem will automatically discover the category and forum name of a given topic
 
     $ zp exists? -f <path_to_markdown_file>
 
+### Images
+
+ZenPush automatically uploads images linked in your markup, provided they can be located on the file system using
+the image path specified.
+
+Image paths are relative to the root of your project. So if you have `![Smiley]('/images/smiley.jpg')`, then ZenPush expects
+your JPEG to be at `<project>/images/smiley.jpg`. If ZenPush cannot locate an image on the file system, you will be warned.
+
+Every time you push a document, images that were previously uploaded are automatically discarded and all images
+are re-uploaded.
+
 ### Markdown Flavors
 
 ZenPush supports two different flavors of markdown: 'standard' and 'github'. The latter flavor supports Github specific

--- a/lib/zenpush/runner.rb
+++ b/lib/zenpush/runner.rb
@@ -42,20 +42,7 @@ module ZenPush
           File.read(options[:file])
         end
 
-      topic = ZenPush.z.find_topic(category_name, forum_name, topic_title)
-      if topic
-        # UPDATE THE TOPIC
-        ap ZenPush.z.put_topic(topic['id'], topic_body)
-      else
-        forum = ZenPush.z.find_or_create_forum(category_name, forum_name)
-        if forum
-          # CREATE THE TOPIC
-          ap ZenPush.z.post_topic(forum['id'], topic_title, topic_body)
-        else
-          ap "Could not find a forum named '#{forum_name}' in the category '#{category_name}'"
-          exit(-1)
-        end
-      end
+      ZenPush.z.create_or_update_topic(category_name, forum_name, topic_title, topic_body, options)
     end
   end
 end

--- a/lib/zenpush/zendesk.rb
+++ b/lib/zenpush/zendesk.rb
@@ -2,10 +2,14 @@
 require 'json'
 require 'yaml'
 require 'httparty'
+require 'persistent_httparty'
+require 'nokogiri'
 
 module ZenPush
   class Zendesk
     include HTTParty
+    persistent_connection_adapter({ :idle_timeout => 30,
+                                    :keep_alive   => 60 })
 
     attr_accessor :options
 
@@ -15,9 +19,9 @@ module ZenPush
     def initialize(options = {})
 
       default_options = {
-        :uri => nil,
-        :user => nil,
-        :password => nil,
+        :uri                                    => nil,
+        :user                                   => nil,
+        :password                               => nil,
         :filenames_use_dashes_instead_of_spaces => false,
       }
 
@@ -29,7 +33,7 @@ module ZenPush
       end
 
       opts = default_options.merge!(options)
-      opts.each_pair { |k,v| raise "#{k} is nil" if v.nil? }
+      opts.each_pair { |k, v| raise "#{k} is nil" if v.nil? }
 
       @options = opts
 
@@ -73,7 +77,7 @@ module ZenPush
       self.get('/users.json', options).parsed_response['users']
     end
 
-    def topics(forum_id, options = { })
+    def topics(forum_id, options = {})
       self.get("/forums/#{forum_id}/topics.json", options).parsed_response['topics']
     end
 
@@ -92,9 +96,9 @@ module ZenPush
     end
 
     # Find category by name, creating it if it doesn't exist
-    def find_or_create_category(category_name, options={ })
+    def find_or_create_category(category_name, options={})
       find_category(category_name, options) || begin
-        post_category(category_name, options={ })
+        post_category(category_name, options={})
       end
     end
 
@@ -102,12 +106,12 @@ module ZenPush
     def find_forum(category_name, forum_name, options = {})
       category = self.find_category(category_name, options)
       if category
-        self.forums.detect {|f| f['name'] == forum_name}
+        self.forums.detect { |f| f['name'] == forum_name }
       end
     end
 
     # Given a category name, find a forum by name. Create the category and forum either doesn't exist.
-    def find_or_create_forum(category_name, forum_name, options={ })
+    def find_or_create_forum(category_name, forum_name, options={})
       category = self.find_or_create_category(category_name, options)
       if category
         self.forums.detect { |f| f['name'] == forum_name } || post_forum(category['id'], forum_name)
@@ -118,12 +122,81 @@ module ZenPush
     def find_topic(category_name, forum_name, topic_title, options = {})
       forum = self.find_forum(category_name, forum_name, options)
       if forum
-        self.topics(forum['id'], options).detect {|t| t['title'] == topic_title}
+        self.topics(forum['id'], options).detect { |t| t['title'] == topic_title }
       end
     end
 
+    def create_or_update_topic(category_name, forum_name, topic_title, topic_body, options = {})
+      topic = ZenPush.z.find_topic(category_name, forum_name, topic_title)
+      if topic
+        update_topic(topic, topic_body, options)
+      else
+        create_topic(category_name, forum_name, topic_title, topic_body, options)
+      end
+    end
+
+    # Create topic by name, knowing the forum name and category name. Automatically uploads images.
+    def create_topic(category_name, forum_name, topic_title, topic_body, options = {})
+      forum = ZenPush.z.find_or_create_forum(category_name, forum_name)
+      if forum
+        topic_body = upload_images(topic_body)
+        post_topic(forum['id'], topic_title, topic_body, options)
+      else
+        raise "Could not find a forum named '#{forum_name}' in the category '#{category_name}'"
+      end
+    end
+
+    # Update topic by name, knowing the forum name and category name. Automatically uploads images.
+    def update_topic(topic, topic_body, options = {})
+      delete_images(topic['body'])
+      topic_body = upload_images(topic_body)
+      put_topic(topic['id'], topic_body, options)
+    end
+
+    # Upload all the attachments linked in the topic body
+    def upload_images(topic_body)
+      doc   = Nokogiri::HTML.fragment(topic_body)
+
+      # Collect all relative links
+      urls  = doc.css('img').collect do |img|
+        img['src'] =~ /^http/i ? nil : img['src']
+      end.compact.uniq
+
+      # Upload files and replace link with Zendesk content URL
+      token = nil
+      urls.collect do |url|
+        file = File.expand_path(File.join('.', URI.unescape(url)))
+        if File.exists?(file)
+          upload = post_upload(file, token)
+          token  ||= upload['token']
+          upload['attachments'].first.tap do |attachment|
+            doc.css('img').each do |img|
+              img['src'] = attachment['content_url'] if img['src'] == url
+            end
+          end
+        else
+          puts "Could not find #{url}. Skipping."
+        end
+      end.flatten
+
+      # Append a comment to the topic HTML to keep track of the upload token
+      if token
+        doc.add_child("<span id=\"upload-token\" data-token=\"#{token}\"></span>")
+        doc.to_html
+      else
+        doc.to_html
+      end
+    end
+
+    # Delete uploaded content for a topic
+    def delete_images(existing_topic_body)
+      doc  = Nokogiri::HTML.fragment(existing_topic_body)
+      span = doc.css('#upload-token').first
+      delete_upload(span['data-token']) if span
+    end
+
     # Create a category with a given name
-    def post_category(category_name, options={ })
+    def post_category(category_name, options={})
       self.post('/categories.json',
                 options.merge(
                   :body => { :category => {
@@ -134,7 +207,7 @@ module ZenPush
     end
 
     # Create a forum in the given category id
-    def post_forum(category_id, forum_name, options={ })
+    def post_forum(category_id, forum_name, options={})
       self.post('/forums.json',
                 options.merge(
                   :body => { :forum => {
@@ -146,7 +219,7 @@ module ZenPush
     end
 
     # Create a topic in the given forum id
-    def post_topic(forum_id, title, body, options = { })
+    def post_topic(forum_id, title, body, options = {})
       self.post("/topics.json",
                 options.merge(
                   :body => { :topic => {
@@ -157,12 +230,26 @@ module ZenPush
     end
 
     # Update a topic in the given forum id
-    def put_topic(id, body, options = { })
+    def put_topic(id, body, options = {})
       self.put("/topics/#{id}.json",
                options.merge(
                  :body => { :topic => { :body => body } }.to_json
                )
       )['topic']
+    end
+
+    # Add an attachment by creating an upload
+    def post_upload(file, token = nil)
+      contents = File.binread(file)
+      self.post("/uploads.json?filename=#{File.basename(file)}#{"&token=#{token}" if token}",
+                :body    => contents,
+                :headers => { 'Content-Type' => 'application/binary' }
+      ).parsed_response['upload']
+    end
+
+    # Delete an upload
+    def delete_upload(token)
+      self.delete("/uploads/#{token}.json") if token
     end
 
   end

--- a/zenpush.gemspec
+++ b/zenpush.gemspec
@@ -19,11 +19,13 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency "boson", "~> 1.0" # Command line
-  s.add_dependency "httparty", "~> 0.8.0" # Zendesk API calls
+  s.add_dependency "httparty", "~> 0.9.0" # Zendesk API calls
+  s.add_dependency "persistent_httparty", "~> 0.1.1" # Use HTTP keep-alive
   s.add_dependency "redcarpet", "~> 2.1.0" # Markdown to HTML
   s.add_dependency "pygments.rb", "~> 0.4.2" # Code highlighting for Github flavored markdown
   s.add_dependency "awesome_print", "~> 1.0.0" # Colorized output of Zendesk responses
   s.add_dependency "json_pure", "~> 1.5.1" # The C-gem "json" will still be used instead if it's installed
+  s.add_dependency "nokogiri" # Parsing HTML prior to uploading in order to find attachments
 
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
### Pull Request Summary
1. persistent connections with Zendesk using `persistent_httparty`
2. automatic uploads of images linked in markup
3. automatic clean up of images previously uploaded
4. using a local .ruby_version file
### Image Uploads

This feature works with Markdown and HTML. Images in the markup point to image files using file system paths. ZenPush handles the rest.
##### On Topic Creation...
- The file system is searched for all relative image links in the HTML
- A Zendesk "upload" is created for all images in the HTML
- The Zendesk upload token is stored in an invisible `span` element in the topic HTML (does not modify local files)
- Topic HTML is rewritten to point to Zendesk URLs for uploaded images (does not modify local files)
##### On  Topic Update...
- On topic update, the upload token is retrieved from the existing topic HTML
- The upload is deleted, thereby deleting all images previously uploaded
- The upload process for Topic creation is invoked
